### PR TITLE
fix for stateless components, only adds refs for stateful ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,4 @@
       "name": "zrumenjak"
     }
   ]
-
 }

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -142,6 +142,7 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
       setNativeProps(nativeProps) {
         if (!this.isRefDefined()) {
           console.warn('setNativeProps can\'nt be used on stateless components');
+          return;
         }
         if (this.wrappedInstance.setNativeProps) {
           this.wrappedInstance.setNativeProps(nativeProps);

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -179,6 +179,8 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
         const addedProps = {};
         if (options.withRef) {
           addedProps.ref = 'wrappedInstance';
+        } else if (WrappedComponent.prototype.render) {
+          addedProps.ref = this.setWrappedInstance;
         }
         return addedProps;
       }
@@ -225,7 +227,6 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
             {...this.props}
             {...addedProps}
             style={style}
-            ref={this.setWrappedInstance}
           />);
       }
     }

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -107,7 +107,6 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
         const resolvedStyle = this.resolveStyle(context, props, styleNames);
         this.setWrappedInstance = this.setWrappedInstance.bind(this);
         this.transformProps = this.transformProps.bind(this);
-        this.isRefDefined = this.isRefDefined.bind(this);
         this.state = {
           style: resolvedStyle.componentStyle,
           childrenStyle: resolvedStyle.childrenStyle,
@@ -117,8 +116,6 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
           addedProps: this.resolveAddedProps(),
           styleNames,
         };
-
-        this.resolveAddedProps = this.resolveAddedProps.bind(this);
       }
 
       getChildContext() {

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -143,6 +143,9 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
       }
 
       setNativeProps(nativeProps) {
+        if (!this.isRefDefined()) {
+          console.warn('setNativeProps can\'nt be used on stateless components');
+        }
         if (this.wrappedInstance.setNativeProps) {
           this.wrappedInstance.setNativeProps(nativeProps);
         }
@@ -180,12 +183,8 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
       }
 
       isRefDefined() {
-        // Ref key exists in the props when it's defined on the component
-        // instance, but it has undefined value and it is non-enumerable.
-        // When it's not passed it doesn't exist in the props.
-        // This is abuse of the specifc ref behaviour but it optimizes number of created refs.
-        const propKeys = Object.getOwnPropertyNames(this.props);
-        return _.indexOf(propKeys, 'ref') >= 0;
+        // Define refs on all stateful containers
+        return WrappedComponent.prototype.render;
       }
 
       resolveAddedProps() {
@@ -193,7 +192,7 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
         if (options.withRef) {
           console.warn('withRef is deprecated');
         }
-        if (this.isRefDefined) {
+        if (this.isRefDefined()) {
           addedProps.ref = this.setWrappedInstance;
         }
         return addedProps;


### PR DESCRIPTION
I was getting tons of warnings for stateless components (https://github.com/shoutem/theme/issues/19), this removes the refs for stateless components (checks if `WrappedComponent.prototype.render` exists before setting ref).
If the `withRef` option is passed, it will use the `wrappedInstance` string as usual. I'm not sure what the string is for, so I didn't want to mess with it.