### PR TITLE
Hotfix/1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/theme",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/theme",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "auto-bind": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/theme",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "description": "Style your components in one place.",
   "scripts": {

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -27,19 +27,6 @@ function throwConnectStyleError(errorMessage, componentDisplayName) {
 }
 
 /**
- * Returns the theme object from the provided context,
- * or an empty theme if the context doesn't contain a theme.
- *
- * @param context The React component context.
- * @returns {Theme} The Theme object.
- */
-function getTheme(context) {
-  // Fallback to a default theme if the component isn't
-  // rendered in a StyleProvider.
-  return context.theme || Theme.getDefaultTheme();
-}
-
-/**
  * Resolves the final component style by using the theme style, if available and
  * merging it with the style provided directly through the style prop, and style
  * variants applied through the styleName prop.
@@ -88,8 +75,6 @@ export default function connectStyle(
     }
 
     class StyledComponent extends PureComponent {
-      static contextType = ThemeContext;
-
       static propTypes = {
         children: PropTypes.node,
         // Element style that overrides any other style of the component
@@ -117,8 +102,8 @@ export default function connectStyle(
 
       static BaseComponent = getBaseComponent(WrappedComponent);
 
-      constructor(props, context) {
-        super(props, context);
+      constructor(props) {
+        super(props);
 
         const styleNames = this.resolveStyleNames(props);
 
@@ -278,30 +263,39 @@ export default function connectStyle(
         const { virtual } = this.props;
 
         return (
-          <StylePropagationContext.Consumer>
-            {({ parentStyle: contextParentStyle }) => {
-              const theme = getTheme(this.context);
-              const resolvedStyle = this.resolveStyle(
-                theme,
-                contextParentStyle,
-              );
-              const childStyle = virtual
-                ? contextParentStyle
-                : resolvedStyle.childrenStyle;
+          <ThemeContext.Consumer>
+            {themeContext => {
+              // Fallback to a default theme if the component isn't
+              // rendered in a StyleProvider.
+              const theme = themeContext.theme || Theme.getDefaultTheme();
 
               return (
-                <StylePropagationContext.Provider
-                  value={{ parentStyle: childStyle }}
-                >
-                  <WrappedComponent
-                    {...this.props}
-                    {...addedProps}
-                    style={resolvedStyle.componentStyle}
-                  />
-                </StylePropagationContext.Provider>
+                <StylePropagationContext.Consumer>
+                  {({ parentStyle: contextParentStyle }) => {
+                    const resolvedStyle = this.resolveStyle(
+                      theme,
+                      contextParentStyle,
+                    );
+                    const childStyle = virtual
+                      ? contextParentStyle
+                      : resolvedStyle.childrenStyle;
+
+                    return (
+                      <StylePropagationContext.Provider
+                        value={{ parentStyle: childStyle }}
+                      >
+                        <WrappedComponent
+                          {...this.props}
+                          {...addedProps}
+                          style={resolvedStyle.componentStyle}
+                        />
+                      </StylePropagationContext.Provider>
+                    );
+                  }}
+                </StylePropagationContext.Consumer>
               );
             }}
-          </StylePropagationContext.Consumer>
+          </ThemeContext.Consumer>
         );
       }
     }


### PR DESCRIPTION
Because of legacy context and because `this`.context was used inside `StylePropagationContext`, it'd resolve to animation driver context, instead of theme....

Fix: Use new context api and refer to theme context in upper scope. Once `themeContext` is resolved, it's the referred to inside child `StylePropagationContext`